### PR TITLE
Adjust the miner tip should adjust the amount of ETH input automatically

### DIFF
--- a/packages/frontend/src/pages/Swap/index.tsx
+++ b/packages/frontend/src/pages/Swap/index.tsx
@@ -296,6 +296,12 @@ export default function Swap({ history }: RouteComponentProps) {
     onCurrencySelection
   ])
 
+  useEffect(() => {
+    if(parsedAmounts[Field.INPUT] && maxAmountInput && parsedAmounts[Field.INPUT]?.greaterThan(maxAmountInput)) {
+      handleMaxInput();
+    }
+  }, [handleMaxInput, maxAmountInput]);
+
   const swapIsUnsupported = useIsTransactionUnsupported(currencies?.INPUT, currencies?.OUTPUT)
 
   return (


### PR DESCRIPTION
[44](https://github.com/archerdao/archerswap/issues/44)

