### PR TITLE
Fix duplicated token line issue in coingecko uniswap list

### DIFF
--- a/packages/frontend/src/constants/lists.ts
+++ b/packages/frontend/src/constants/lists.ts
@@ -7,7 +7,7 @@ const SYNTHETIX_LIST = 'synths.snx.eth'
 const WRAPPED_LIST = 'wrapped.tokensoft.eth'
 const OPYN_LIST = 'https://raw.githubusercontent.com/opynfinance/opyn-tokenlist/master/opyn-v1.tokenlist.json'
 const ROLL_LIST = 'https://app.tryroll.com/tokens.json'
-// const COINGECKO_LIST = 'https://tokens.coingecko.com/uniswap/all.json'
+const COINGECKO_LIST = 'https://tokens.coingecko.com/uniswap/all.json'
 const CMC_ALL_LIST = 'defi.cmc.eth'
 const CMC_STABLECOIN = 'stablecoin.cmc.eth'
 const KLEROS_LIST = 't2crtokens.eth'
@@ -26,7 +26,7 @@ export const DEFAULT_LIST_OF_LISTS: string[] = [
   WRAPPED_LIST,
   OPYN_LIST,
   ROLL_LIST,
-  // COINGECKO_LIST,
+  COINGECKO_LIST,
   CMC_ALL_LIST,
   CMC_STABLECOIN,
   KLEROS_LIST,

--- a/packages/frontend/src/state/lists/hooks.ts
+++ b/packages/frontend/src/state/lists/hooks.ts
@@ -61,7 +61,12 @@ export function listToTokenMap(list: TokenList): TokenAddressMap {
           })
           ?.filter((x): x is TagInfo => Boolean(x)) ?? []
       const token = new WrappedTokenInfo(tokenInfo, tags)
-      if (tokenMap[token.chainId as ChainId][token.address] !== undefined) throw Error('Duplicate tokens.')
+      if (tokenMap[token.chainId as ChainId][token.address] !== undefined) {
+        if(token?.name === 'e Money') {
+          return tokenMap;  
+        }
+        throw Error('Duplicate tokens.')
+      }
       return {
         ...tokenMap,
         [token.chainId]: {


### PR DESCRIPTION
*Description*
There are duplicated lines in the coingecko uniswap token list.
Here is the info.
{"chainId":1,"address":"0xed0d5747a9ab03a75fbfec3228cd55848245b75d","name":"e Money","symbol":"NGM","decimals":6,"logoURI":"https://assets.coingecko.com/coins/images/13722/thumb/nx5m_kZJt3oz9UM0XhE-IEeJ8TGjX1831iNfLVWeMvHuYoyDGwN0vh9Wj8u5hCxe1u5Kw56zT5kqX_ia5u1hsMElA-ioKCvK2jUK4EdJMDUx4J1GOnjqIu30iXHrLfmdzqO2SyucZZZnutFVLIAkxWMcTbIo1GDPZ3dZSj2onSeEOnIY4GJKR9B6ByR1XUZrJxtpY9QjwoWLfPC.jpg?1611182880"}